### PR TITLE
feat: add docs copy page, open in ai apps and markdown

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next";
 import { DocsPage, DocsBody } from "@/components/layout/docs/page";
 import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
+import { DocsCopyPage } from "@/components/docs-copy-page";
+import { absoluteUrl } from "@/lib/utils";
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -12,11 +14,18 @@ export default async function Page(props: {
   if (!page) notFound();
 
   const MDX = page.data.body;
+  const raw = await page.data.getText("raw");
+  const pageUrl = absoluteUrl(page.url);
 
   return (
     <DocsPage toc={page.data.toc}>
       <DocsBody>
-        <h1>{page.data.title}</h1>
+        <div className="flex items-start justify-between mb-6 gap-4 flex-wrap">
+          <h1 className="flex-1 min-w-0">{page.data.title}</h1>
+          <div className="shrink-0">
+            <DocsCopyPage page={raw} url={pageUrl} />
+          </div>
+        </div>
         <MDX components={{ ...defaultMdxComponents }} />
       </DocsBody>
     </DocsPage>

--- a/app/llm/[[...slug]]/route.ts
+++ b/app/llm/[[...slug]]/route.ts
@@ -1,0 +1,40 @@
+import { notFound } from "next/navigation";
+import { NextResponse, type NextRequest } from "next/server";
+
+import { convertMdxToMarkdown } from "@/lib/llm";
+import { source } from "@/lib/source";
+
+export const revalidate = false;
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ slug?: string[] }> }
+) {
+  const { slug } = await params;
+
+  if (!slug || slug.length === 0) {
+    notFound();
+  }
+
+  const cleanSlug = slug.map((s, i) =>
+    i === slug.length - 1 ? s.replace(/\.md$/, "") : s
+  );
+
+  const page = source.getPage(cleanSlug);
+
+  if (!page) {
+    notFound();
+  }
+
+  const processedContent = convertMdxToMarkdown(await page.data.getText("raw"));
+
+  return new NextResponse(processedContent, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}
+
+export function generateStaticParams() {
+  return source.generateParams();
+}

--- a/components/docs-copy-page.tsx
+++ b/components/docs-copy-page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import {
+  ArrowDown01Icon,
+  Copy02Icon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+function getPromptUrl(baseURL: string, url: string) {
+  return `${baseURL}?q=${encodeURIComponent(
+    `I'm looking at this useLayouts documentation: ${url}.
+Help me understand how to use it. Be ready to explain concepts, give examples, or help debug based on it.`
+  )}`;
+}
+
+const menuItems = {
+  markdown: {
+    icon: (
+      <svg strokeLinejoin="round" viewBox="0 0 22 16" className="size-4">
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M19.5 2.25H2.5C1.80964 2.25 1.25 2.80964 1.25 3.5V12.5C1.25 13.1904 1.80964 13.75 2.5 13.75H19.5C20.1904 13.75 20.75 13.1904 20.75 12.5V3.5C20.75 2.80964 20.1904 2.25 19.5 2.25ZM2.5 1C1.11929 1 0 2.11929 0 3.5V12.5C0 13.8807 1.11929 15 2.5 15H19.5C20.8807 15 22 13.8807 22 12.5V3.5C22 2.11929 20.8807 1 19.5 1H2.5ZM3 4.5H4H4.25H4.6899L4.98715 4.82428L7 7.02011L9.01285 4.82428L9.3101 4.5H9.75H10H11V5.5V11.5H9V7.79807L7.73715 9.17572L7 9.97989L6.26285 9.17572L5 7.79807V11.5H3V5.5V4.5ZM15 8V4.5H17V8H19.5L17 10.5L16 11.5L15 10.5L12.5 8H15Z"
+          fill="currentColor"
+        />
+      </svg>
+    ),
+    label: "View as Markdown",
+    getHref: (url: string) => `${url}.md`,
+  },
+  chatgpt: {
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        className="size-4"
+      >
+        <path
+          d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08-4.778 2.758a.795.795 0 0 0-.393.681zm1.097-2.365 2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5Z"
+          fill="currentColor"
+        />
+      </svg>
+    ),
+    label: "Open in ChatGPT",
+    getHref: (url: string) => getPromptUrl("https://chatgpt.com", url),
+  },
+  claude: {
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        className="size-4"
+      >
+        <path
+          d="m4.714 15.956 4.718-2.648.079-.23-.08-.128h-.23l-.79-.048-2.695-.073-2.337-.097-2.265-.122-.57-.121-.535-.704.055-.353.48-.321.685.06 1.518.104 2.277.157 1.651.098 2.447.255h.389l.054-.158-.133-.097-.103-.098-2.356-1.596-2.55-1.688-1.336-.972-.722-.491L2 6.223l-.158-1.008.655-.722.88.06.225.061.893.686 1.906 1.476 2.49 1.833.364.304.146-.104.018-.072-.164-.274-1.354-2.446-1.445-2.49-.644-1.032-.17-.619a2.972 2.972 0 0 1-.103-.729L6.287.133 6.7 0l.995.134.42.364.619 1.415L9.735 4.14l1.555 3.03.455.898.243.832.09.255h.159V9.01l.127-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.583.28.48.685-.067.444-.286 1.851-.558 2.903-.365 1.942h.213l.243-.242.983-1.306 1.652-2.064.728-.82.85-.904.547-.431h1.032l.759 1.129-.34 1.166-1.063 1.347-.88 1.142-1.263 1.7-.79 1.36.074.11.188-.02 2.853-.606 1.542-.28 1.84-.315.832.388.09.395-.327.807-1.967.486-2.307.462-3.436.813-.043.03.049.061 1.548.146.662.036h1.62l3.018.225.79.522.473.638-.08.485-1.213.62-1.64-.389-3.825-.91-1.31-.329h-.183v.11l1.093 1.068 2.003 1.81 2.508 2.33.127.578-.321.455-.34-.049-2.204-1.657-.85-.747-1.925-1.62h-.127v.17l.443.649 2.343 3.521.122 1.08-.17.353-.607.213-.668-.122-1.372-1.924-1.415-2.168-1.141-1.943-.14.08-.674 7.254-.316.37-.728.28-.607-.461-.322-.747.322-1.476.388-1.924.316-1.53.285-1.9.17-.632-.012-.042-.14.018-1.432 1.967-2.18 2.945-1.724 1.845-.413.164-.716-.37.066-.662.401-.589 2.386-3.036 1.439-1.882.929-1.086-.006-.158h-.055L4.138 18.56l-1.13.146-.485-.456.06-.746.231-.243 1.907-1.312Z"
+          fill="currentColor"
+        />
+      </svg>
+    ),
+    label: "Open in Claude",
+    getHref: (url: string) => getPromptUrl("https://claude.ai/new", url),
+  },
+  v0: {
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="currentColor"
+        viewBox="0 0 147 70"
+        className="size-4.5 -translate-x-px"
+      >
+        <path d="M56 50.203V14h14v46.156C70 65.593 65.593 70 60.156 70c-2.596 0-5.158-1-7-2.843L0 14h19.797L56 50.203ZM147 56h-14V23.953L100.953 56H133v14H96.687C85.814 70 77 61.186 77 50.312V14h14v32.156L123.156 14H91V0h36.312C138.186 0 147 8.814 147 19.688V56Z" />
+      </svg>
+    ),
+    label: "Open in v0",
+    getHref: (url: string) => getPromptUrl("https://v0.dev", url),
+  },
+};
+
+export function DocsCopyPage({ page, url }: { page: string; url: string }) {
+  const { copyToClipboard, isCopied } = useCopyToClipboard();
+
+  return (
+    <DropdownMenu>
+      <div className="bg-secondary group/buttons relative flex rounded-lg shadow-sm">
+        <Button
+          variant="secondary"
+          size="sm"
+          className="h-8 shadow-none md:h-7 md:text-[0.8rem] rounded-r-none border-r-0"
+          onClick={() => copyToClipboard(page)}
+        >
+          {isCopied ? (
+            <HugeiconsIcon icon={Tick02Icon} size={16} className="size-4" />
+          ) : (
+            <HugeiconsIcon icon={Copy02Icon} size={16} className="size-4" />
+          )}
+          <span className="hidden md:inline">Copy Page</span>
+        </Button>
+
+        <Separator
+          orientation="vertical"
+          className="!bg-foreground/10 h-8 md:h-7"
+        />
+
+        <DropdownMenuTrigger
+          className={cn(
+            buttonVariants({ variant: "secondary", size: "sm" }),
+            "h-8 shadow-none md:h-7 md:text-[0.8rem] rounded-l-none px-2 border-l-0"
+          )}
+        >
+          <HugeiconsIcon icon={ArrowDown01Icon} size={16} className="size-4" />
+        </DropdownMenuTrigger>
+      </div>
+
+      <DropdownMenuContent align="end" className="shadow-md min-w-[200px]">
+        {Object.entries(menuItems).map(([key, item]) => (
+          <DropdownMenuItem key={key}>
+            <a
+              href={item.getHref(url)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 w-full"
+            >
+              {item.icon}
+              {item.label}
+            </a>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/hooks/use-copy-to-clipboard.ts
+++ b/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+
+export function useCopyToClipboard({
+  timeout = 2000,
+  onCopy,
+}: {
+  timeout?: number;
+  onCopy?: () => void;
+} = {}) {
+  const [isCopied, setIsCopied] = React.useState(false);
+
+  const copyToClipboard = (value: string) => {
+    if (typeof window === "undefined" || !navigator.clipboard.writeText) {
+      return;
+    }
+
+    if (!value) return;
+
+    navigator.clipboard.writeText(value).then(() => {
+      setIsCopied(true);
+
+      if (onCopy) {
+        onCopy();
+      }
+
+      if (timeout !== 0) {
+        setTimeout(() => {
+          setIsCopied(false);
+        }, timeout);
+      }
+    }, console.error);
+  };
+
+  return { isCopied, copyToClipboard };
+}

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,0 +1,51 @@
+import fs from "fs";
+import { Index } from "@/registry/__index__";
+
+function replaceComponentTags(content: string): string {
+  const regex =
+    /<(?:ComponentPreview|SourceCode)[\s\S]*?name=["']([^"']+)["'][\s\S]*?\/>/g;
+
+  return content.replace(regex, (match, name: string) => {
+    try {
+      const component = Index[name];
+      if (!component?.files?.length) return match;
+
+      const src = component.files[0]?.path;
+      if (!src) return match;
+
+      const source = fs
+        .readFileSync(src, "utf8")
+        .replaceAll("@/registry/default/", "@/components/")
+        .replaceAll("export default", "export");
+
+      return `\`\`\`tsx\n${source}\n\`\`\``;
+    } catch (error) {
+      console.error(`Error processing component "${name}":`, error);
+      return match;
+    }
+  });
+}
+
+function removeDocImports(content: string): string {
+  const patterns = [
+    /^\s*import\s*\{[^}]*\}\s*from\s*["']fumadocs-ui\/components\/[^"']+["'];?\s*\n?/gm,
+    /^\s*import\s*\{[^}]*\}\s*from\s*["']@\/components\/(source-code|component-preview)["'];?\s*\n?/gm,
+  ];
+
+  let result = content;
+  for (const pattern of patterns) {
+    result = result.replace(pattern, "");
+  }
+
+  return result;
+}
+
+export function convertMdxToMarkdown(content: string): string {
+  let processed = content;
+
+  processed = removeDocImports(processed);
+  processed = replaceComponentTags(processed);
+  processed = processed.replace(/\n{3,}/g, "\n\n");
+
+  return processed.trim();
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Get absolute URL for a given path
+ * @param path - The relative path (e.g., "/docs/components/bucket")
+ * @returns Absolute URL (e.g., "https://uselayouts.com/docs/components/bucket")
+ */
+export function absoluteUrl(path: string) {
+  const baseUrl = "https://uselayouts.com";
+  return `${baseUrl}${path}`;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,6 +24,14 @@ const config = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: "/docs/:path*.md",
+        destination: "/llm/:path*",
+      },
+    ];
+  },
 };
 
 const withMDX = createMDX({


### PR DESCRIPTION
In this PR, I’ve added the following things:

1. Add copy button to copy documentation content
2. Open as markdown by adding .md to the end of the component URL
3. Open in AI apps like ChatGPT, Claude, and v0 with a prefilled helper prompt.

here's preview image:

<img width="1059" height="267" alt="image" src="https://github.com/user-attachments/assets/156526a5-b72a-4b5c-87f3-5fe8ed958695" />
