### PR TITLE
Updated Inline-edit and added 6 more components

### DIFF
--- a/content/docs/components/add-cash.mdx
+++ b/content/docs/components/add-cash.mdx
@@ -1,0 +1,157 @@
+---
+title: Add Cash
+description: A premium animated wallet top-up interaction with morphing disclosure, shared layout transitions, and fluid selection animations.
+---
+
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { SourceCode } from "@/components/source-code";
+import { ComponentPreview } from "@/components/component-preview";
+
+<Tabs items={["Preview", "Code"]}>
+  <Tab value="Preview">
+    <ComponentPreview name="add-cash" />
+  </Tab>
+
+  <Tab value="Code">
+    <SourceCode name="add-cash" />
+  </Tab>
+</Tabs>
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+  <Tab value="CLI">
+
+```bash
+npx shadcn@latest add "https://uselayouts.com/r/add-cash.json"
+```
+
+  </Tab>
+
+  <Tab value="Manual">
+
+<Steps>
+  <Step>
+
+### Install dependencies
+
+```bash
+npm install motion
+```
+
+  </Step>
+
+  <Step>
+
+### Copy the component
+
+Copy the code from the **Code** tab above into:
+
+```bash
+components/add-cash.tsx
+```
+
+  </Step>
+
+  <Step>
+
+### Update imports
+
+Update import paths to match your project structure.
+
+  </Step>
+</Steps>
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+### Basic Usage
+
+```tsx
+import AddCashWidget from "@/components/add-cash";
+
+export default function Page() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <AddCashWidget />
+    </div>
+  );
+}
+```
+
+---
+
+## Customization
+
+### Update Wallet Balance
+
+You can change the initial wallet amount by updating the `balance` state:
+
+```tsx
+const [balance, setBalance] = useState(34);
+```
+
+---
+
+### Customize Payment Cards
+
+Modify the `cards` array to add or remove payment methods:
+
+```tsx
+const cards = [
+  {
+    id: "6756",
+    icon: <VisaIcon />,
+  },
+  {
+    id: "4632",
+    icon: <MastercardIcon />,
+  },
+];
+```
+
+---
+
+### Update Amount Chips
+
+Modify the default amount values:
+
+```tsx
+const [chipValues, setChipValues] = useState([
+  "50",
+  "100",
+  "300",
+]);
+```
+
+---
+
+### Adjust Spring Animation
+
+The interaction uses a tight spring for smooth premium motion:
+
+```tsx
+const SP = {
+  type: "spring",
+  stiffness: 520,
+  damping: 42,
+  mass: 0.72,
+};
+```
+
+---
+
+## Features
+
+- **Morphing Disclosure Animation** — Smooth expandable wallet interaction using shared layout transitions.
+- **Shared Selection Outline** — Active card and amount chips use animated floating outlines powered by `layoutId`.
+- **Fluid Height Interpolation** — Expands and collapses without snapping or abrupt layout shifts.
+- **Animated Button States** — CTA transitions between idle, loading, and completed states.
+- **Interactive Amount Inputs** — Editable amount chips with animated selection states.
+- **Premium Motion Design** — Tight spring physics inspired by Linear, Raycast, and modern iOS interactions.
+- **Morphing Action Button** — “Add Cash” button transforms into a close button using shared layouts.
+- **Micro-interactions** — Includes hover states, press animations, shine effects, and smooth transitions.
+- **Fully Customizable** — Easily swap payment methods, chip values, labels, and animations.

--- a/content/docs/components/copy-button.mdx
+++ b/content/docs/components/copy-button.mdx
@@ -1,0 +1,98 @@
+---
+title: Copy Button
+description: An animated copy button with smooth morphing transitions and success feedback states.
+---
+
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { SourceCode } from "@/components/source-code";
+import { ComponentPreview } from "@/components/component-preview";
+
+<Tabs items={["Preview", "Code"]}>
+  <Tab value="Preview">
+    <ComponentPreview name="copy-button" />
+  </Tab>
+
+  <Tab value="Code">
+    <SourceCode name="copy-button" />
+  </Tab>
+</Tabs>
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+  <Tab value="CLI">
+
+```bash
+npx shadcn@latest add "https://uselayouts.com/r/copy-button.json"
+```
+
+  </Tab>
+
+  <Tab value="Manual">
+
+<Steps>
+  <Step>
+
+### Install dependencies
+
+```bash
+npm install motion @hugeicons/react @hugeicons/core-free-icons
+```
+
+  </Step>
+
+  <Step>
+
+### Copy the code
+
+Copy the code from the **Code** tab above into:
+
+```bash
+components/copy-button.tsx
+```
+
+  </Step>
+
+  <Step>
+
+### Update imports
+
+Update the imports to match your project structure.
+
+  </Step>
+</Steps>
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+### Customizing Content
+
+You can customize the button labels by editing the text variables inside the component:
+
+```tsx
+// Change Here
+const copyText = "Copy";
+const copiedText = "Copied";
+```
+
+```tsx
+import CopyButton from "@/components/copy-button";
+
+export default function Page() {
+  return <CopyButton />;
+}
+```
+
+## Features
+
+- **Morphing Animation** - Smooth transition between copy and copied states
+- **Clipboard Interaction** - Copies content instantly with a single click
+- **Success Feedback** - Visual confirmation when content is copied
+- **Animated Icons** - Dynamic icon transitions for better interaction feedback
+- **Micro-interactions** - Subtle scale, opacity, and motion effects
+- **Reusable Component** - Easily integrate into dashboards, code blocks, or command snippets
+- **Customizable Labels** - Quickly modify button text and copied content
+- **Accessible Design** - Keyboard and screen-reader friendly interactions

--- a/content/docs/components/counter.mdx
+++ b/content/docs/components/counter.mdx
@@ -1,0 +1,104 @@
+---
+title: Counter
+description: An animated counter component with smooth number transitions and interactive increment/decrement controls.
+---
+
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { SourceCode } from "@/components/source-code";
+import { ComponentPreview } from "@/components/component-preview";
+
+<Tabs items={["Preview", "Code"]}>
+  <Tab value="Preview">
+    <ComponentPreview name="counter" />
+  </Tab>
+
+  <Tab value="Code">
+    <SourceCode name="counter" />
+  </Tab>
+</Tabs>
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+  <Tab value="CLI">
+
+```bash
+npx shadcn@latest add "https://uselayouts.com/r/counter.json"
+```
+
+  </Tab>
+
+  <Tab value="Manual">
+
+<Steps>
+  <Step>
+
+### Install dependencies
+
+```bash
+npm install motion
+```
+
+  </Step>
+
+  <Step>
+
+### Copy the code
+
+Copy the code from the **Code** tab above into:
+
+```bash
+components/counter.tsx
+```
+
+  </Step>
+
+  <Step>
+
+### Update imports
+
+Update the imports to match your project structure.
+
+  </Step>
+</Steps>
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+### Customizing Limits
+
+You can customize the minimum value, maximum value, and initial count using props:
+
+```tsx
+<Counter
+  min={0}
+  max={20}
+  defaultValue={5}
+/>
+```
+
+```tsx
+import Counter from "@/components/counter";
+
+export default function Page() {
+  return (
+    <div className="flex items-center justify-center h-[400px] w-full">
+      <Counter />
+    </div>
+  );
+}
+```
+
+## Features
+
+- **Animated Number Transitions** - Numbers slide smoothly when incrementing or decrementing
+- **Directional Motion** - Animation direction changes based on increase or decrease
+- **Interactive Controls** - Responsive plus and minus buttons with tap feedback
+- **Boundary Limits** - Prevents values from exceeding minimum or maximum constraints
+- **Accessible Interactions** - Disabled states for invalid actions
+- **Minimal Design** - Clean UI suitable for dashboards, carts, and quantity selectors
+- **Spring-like Motion** - Smooth easing powered by Motion
+- **Customizable Props** - Easily configure ranges and starting values

--- a/content/docs/components/flower-menu.mdx
+++ b/content/docs/components/flower-menu.mdx
@@ -1,0 +1,89 @@
+---
+title: Flower Menu
+description: A radial flower-style action menu with premium staggered motion and smooth easing curves.
+---
+
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { SourceCode } from "@/components/source-code";
+import { ComponentPreview } from "@/components/component-preview";
+
+<Tabs items={["Preview", "Code"]}>
+  <Tab value="Preview">
+    <ComponentPreview name="flower-menu" />
+  </Tab>
+  <Tab value="Code">
+    <SourceCode name="flower-menu" />
+  </Tab>
+</Tabs>
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add "https://uselayouts.com/r/flower-menu.json"
+    ```
+  </Tab>
+  <Tab value="Manual">
+    <Steps>
+      <Step>
+        ### Install dependencies
+
+        ```bash
+        npm install motion lucide-react
+        ```
+      </Step>
+      <Step>
+        ### Copy the component
+
+        Copy code from the **Code** tab into:
+
+        ```bash
+        components/flower-menu.tsx
+        ```
+      </Step>
+      <Step>
+        ### Update imports
+
+        Update import paths for your project structure.
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+import FlowerMenu from "@/components/flower-menu";
+
+export default function Page() {
+  return <FlowerMenu />;
+}
+```
+
+## Customization
+
+Update `FLOWER_ACTIONS` to change icons, labels, angle, and petal color:
+
+```tsx
+const FLOWER_ACTIONS = [
+  { id: "calendar", label: "Calendar", Icon: CalendarDays, angle: -145, color: "bg-violet-500" },
+  // ...
+];
+```
+
+For a slower/faster feel, tune `SPRING` and `CURVE`:
+
+```tsx
+const SPRING = { type: "spring", stiffness: 520, damping: 32, mass: 0.8 };
+const CURVE = [0.22, 1, 0.36, 1];
+```
+
+## Features
+
+- Radial flower expansion from a central action button
+- Slow-in / speed-up / slow-out motion curve for premium feel
+- Staggered petal entrance and exit
+- Active action label micro-interaction
+- Dark-mode-friendly styling

--- a/content/docs/components/stepper.mdx
+++ b/content/docs/components/stepper.mdx
@@ -1,0 +1,116 @@
+---
+title: Stepper 
+description: An animated multi-step progress component with smooth transitions, active indicators, and morphing step states.
+---
+
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { SourceCode } from "@/components/source-code";
+import { ComponentPreview } from "@/components/component-preview";
+
+<Tabs items={["Preview", "Code"]}>
+  <Tab value="Preview">
+    <ComponentPreview name="stepper" />
+  </Tab>
+
+  <Tab value="Code">
+    <SourceCode name="stepper" />
+  </Tab>
+</Tabs>
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+  <Tab value="CLI">
+
+```bash
+npx shadcn@latest add "https://uselayouts.com/r/stepper.json"
+```
+
+  </Tab>
+
+  <Tab value="Manual">
+
+<Steps>
+  <Step>
+
+### Install dependencies
+
+```bash
+npm install motion clsx @hugeicons/react @hugeicons/core-free-icons
+```
+
+  </Step>
+
+  <Step>
+
+### Copy the code
+
+Copy the code from the **Code** tab above into:
+
+```bash
+components/stepper.tsx
+```
+
+  </Step>
+
+  <Step>
+
+### Update imports
+
+Update the imports to match your project structure.
+
+  </Step>
+</Steps>
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+### Customizing Steps
+
+You can customize the step labels, icons, and completion states by editing the `steps` array:
+
+```tsx
+// Change Here
+export const steps = [
+  {
+    title: "Account",
+    description: "Create your account",
+  },
+  {
+    title: "Profile",
+    description: "Setup your profile",
+  },
+  {
+    title: "Complete",
+    description: "Finish onboarding",
+  },
+];
+```
+
+```tsx
+import StepperInteraction from "@/components/stepper";
+
+export default function Page() {
+  return (
+    <div className="flex items-center justify-center h-[400px] w-full">
+      <StepperInteraction />
+    </div>
+  );
+}
+```
+
+## Features
+
+- **Animated progress states** - Smooth transitions between active, completed, and upcoming steps
+- **Shared layout animations** - Fluid morphing indicators powered by Framer Motion
+- **Step completion indicators** - Animated checkmarks for completed steps
+- **Interactive navigation** - Clickable steps with hover and focus states
+- **Progress connector animation** - Connecting line fills dynamically as progress advances
+- **Responsive layout** - Adapts beautifully across different screen sizes
+- **Spring-based motion** - Natural animations with configurable easing and bounce
+- **Accessible interactions** - Keyboard-friendly and screen-reader compatible
+- **Customizable content** - Easily modify titles, descriptions, and icons
+- **Minimal design system** - Clean UI that integrates seamlessly into dashboards and onboarding flows

--- a/content/docs/components/swap-form.mdx
+++ b/content/docs/components/swap-form.mdx
@@ -1,0 +1,139 @@
+---
+title: Swap Form
+description: A premium animated authentication form with smooth transitions between sign in and sign up states.
+---
+
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { SourceCode } from "@/components/source-code";
+import { ComponentPreview } from "@/components/component-preview";
+
+<Tabs items={["Preview", "Code"]}>
+  <Tab value="Preview">
+    <ComponentPreview name="swap-form" full />
+  </Tab>
+
+  <Tab value="Code">
+    <SourceCode name="swap-form" />
+  </Tab>
+</Tabs>
+
+## Installation
+
+<Tabs items={['CLI', 'Manual']}>
+  <Tab value="CLI">
+    ```bash
+    npx shadcn@latest add "https://uselayouts.com/r/swap-form.json"
+    ```
+  </Tab>
+
+  <Tab value="Manual">
+    <Steps>
+      <Step>
+        ### Install dependencies
+
+        ```bash
+        npm install motion
+        ```
+      </Step>
+
+      <Step>
+        ### Copy the code
+
+        Copy the code from the **Code** tab above into `components/swap-form.tsx`.
+      </Step>
+
+      <Step>
+        ### Update imports
+
+        Update the imports to match your project structure.
+      </Step>
+    </Steps>
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+### Customizing Content
+
+You can customize the authentication titles and descriptions directly inside the component:
+
+```tsx
+// Change Here
+const isSignUp = mode === "signup";
+
+<h1>
+  {isSignUp ? "Create Account" : "Welcome Back"}
+</h1>
+
+<p>
+  {isSignUp
+    ? "Just one more step to get started."
+    : "Sign in to continue."}
+</p>
+```
+
+#### Input Fields
+
+You can easily add or remove form fields by modifying the form section:
+
+```tsx
+<InputField
+  label="Full Name"
+  type="text"
+  placeholder="Your name"
+/>
+
+<InputField
+  label="Email"
+  type="email"
+  placeholder="you@example.com"
+/>
+```
+
+#### Animation Configuration
+
+The main animation behavior is controlled using the spring configuration:
+
+```tsx
+const SPRING = {
+  type: "spring",
+  stiffness: 520,
+  damping: 38,
+  mass: 0.7,
+};
+```
+
+You can also customize transition timing:
+
+```tsx
+const EASE = {
+  duration: 0.22,
+  ease: [0.4, 0, 0.2, 1],
+};
+```
+
+```tsx
+import SwapForm from "@/components/swap-form";
+
+export default function Page() {
+  return (
+    <div className="max-w-2xl mx-auto py-12">
+      <SwapForm />
+    </div>
+  );
+}
+```
+
+## Features
+
+- **Morphing Auth States** - Smooth transitions between Sign In and Sign Up modes
+- **Shared Layout Animations** - Fluid layout and height interpolation
+- **Premium Motion Design** - Spring-based animations with polished interactions
+- **Glassmorphism UI** - Frosted translucent card with layered depth
+- **Animated Cursor Glow** - Interactive radial highlight effect
+- **Reusable Components** - Modular input fields and social login buttons
+- **Micro Interactions** - Hover, tap, and focus animations throughout
+- **Responsive Layout** - Adaptive authentication card that fits inside preview containers
+- **Optimized Performance** - Reduced layout thrashing and smoother transitions

--- a/registry.json
+++ b/registry.json
@@ -192,6 +192,19 @@
       ]
     },
     {
+      "name": "flower-menu",
+      "type": "registry:component",
+      "title": "Flower Menu",
+      "description": "A radial flower-style quick actions menu with staggered smooth motion.",
+      "dependencies": ["motion", "lucide-react", "clsx", "tailwind-merge"],
+      "files": [
+        {
+          "path": "registry/default/example/flower-menu.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
       "name": "folder-interaction",
       "type": "registry:component",
       "title": "Folder Interaction",
@@ -510,6 +523,71 @@
       "files": [
         {
           "path": "registry/default/example/empty-testimonial.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "add-cash",
+      "type": "registry:component",
+      "title": "Add Cash",
+      "description": "A premium animated wallet top-up interaction with morphing disclosure and smooth selection transitions.",
+      "dependencies": ["motion"],
+      "files": [
+        {
+          "path": "registry/default/example/add-cash.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "copy-button",
+      "type": "registry:component",
+      "title": "Copy Button",
+      "description": "A compact copy interaction button with animated success feedback.",
+      "dependencies": ["motion"],
+      "files": [
+        {
+          "path": "registry/default/example/copy-button.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "counter",
+      "type": "registry:component",
+      "title": "Counter",
+      "description": "An animated numeric counter with smooth increment and decrement transitions.",
+      "dependencies": ["motion"],
+      "files": [
+        {
+          "path": "registry/default/example/counter.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "stepper",
+      "type": "registry:component",
+      "title": "Stepper",
+      "description": "An animated stepper interface for multi-step progress flows.",
+      "dependencies": ["motion"],
+      "files": [
+        {
+          "path": "registry/default/example/stepper.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "swap-form",
+      "type": "registry:component",
+      "title": "Swap Form",
+      "description": "A form panel with animated mode switching and fluid content transitions.",
+      "dependencies": ["motion"],
+      "files": [
+        {
+          "path": "registry/default/example/swap-form.tsx",
           "type": "registry:component"
         }
       ]

--- a/registry/__index__.tsx
+++ b/registry/__index__.tsx
@@ -60,60 +60,6 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
-  "copy-button": {
-    name: "copy-button",
-    description: "A button that copies text to the clipboard with visual feedback.",
-    type: "registry:component",
-    registryDependencies: undefined,
-    files: [{
-      path: "registry/default/example/copy-button.tsx",
-      type: "registry:component",
-      target: ""
-    }],
-    component: React.lazy(async () => {
-      const mod = await import("@/registry/default/example/copy-button.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "copy-button"
-      return { default: mod.default || mod[exportName] }
-    }),
-    categories: undefined,
-    meta: undefined,
-  },
-  "stepper": {
-    name: "stepper",
-    description: "An interactive stepper component with smooth transitions and visual feedback.",
-    type: "registry:component",
-    registryDependencies: undefined,
-    files: [{
-      path: "registry/default/example/stepper.tsx",
-      type: "registry:component",
-      target: ""
-    }],
-    component: React.lazy(async () => {
-      const mod = await import("@/registry/default/example/stepper")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "stepper"
-      return { default: mod.default || mod[exportName] }
-    }),
-    categories: undefined,
-    meta: undefined,
-  },
-  "counter": {
-    name: "counter",
-    description: "A simple counter component with smooth animations.",
-    type: "registry:component",
-    registryDependencies: undefined,
-    files: [{
-      path: "registry/default/example/counter.tsx",
-      type: "registry:component",
-      target: ""
-    }],
-    component: React.lazy(async () => {
-      const mod = await import("@/registry/default/example/counter")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "counter"
-      return { default: mod.default || mod[exportName] }
-    }),
-    categories: undefined,
-    meta: undefined,
-  },
   "day-picker": {
     name: "day-picker",
     description: "A custom day picker component with smooth animations.",
@@ -243,6 +189,24 @@ export const Index: Record<string, any> = {
     component: React.lazy(async () => {
       const mod = await import("@/registry/default/demo/feature-carousel-demo.tsx")
       const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "feature-carousel"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "flower-menu": {
+    name: "flower-menu",
+    description: "A radial flower-style quick actions menu with staggered smooth motion.",
+    type: "registry:component",
+    registryDependencies: undefined,
+    files: [{
+      path: "registry/default/example/flower-menu.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/flower-menu.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "flower-menu"
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -540,29 +504,11 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
-    "swap-form": {
-    name: "swap-form",
-    description: "A dynamic, animated swap form with validation.",
-    type: "registry:component",
-    registryDependencies: ["card","button","input","textarea","select","badge","calendar","popover"],
-    files: [{
-      path: "registry/default/example/swap-form.tsx",
-      type: "registry:component",
-      target: ""
-    }],
-    component: React.lazy(async () => {
-      const mod = await import("@/registry/default/example/swap-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "swap-form"
-      return { default: mod.default || mod[exportName] }
-    }),
-    categories: undefined,
-    meta: undefined,
-  },
-      "add-cash": {
+  "add-cash": {
     name: "add-cash",
-    description: "A dynamic, animated add cash widget with validation.",
+    description: "A premium animated wallet top-up interaction with morphing disclosure and smooth selection transitions.",
     type: "registry:component",
-    registryDependencies: ["card","button","input","textarea","select","badge","calendar","popover"],
+    registryDependencies: undefined,
     files: [{
       path: "registry/default/example/add-cash.tsx",
       type: "registry:component",
@@ -571,6 +517,78 @@ export const Index: Record<string, any> = {
     component: React.lazy(async () => {
       const mod = await import("@/registry/default/example/add-cash.tsx")
       const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "add-cash"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "copy-button": {
+    name: "copy-button",
+    description: "A compact copy interaction button with animated success feedback.",
+    type: "registry:component",
+    registryDependencies: undefined,
+    files: [{
+      path: "registry/default/example/copy-button.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/copy-button.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "copy-button"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "counter": {
+    name: "counter",
+    description: "An animated numeric counter with smooth increment and decrement transitions.",
+    type: "registry:component",
+    registryDependencies: undefined,
+    files: [{
+      path: "registry/default/example/counter.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/counter.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "counter"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "stepper": {
+    name: "stepper",
+    description: "An animated stepper interface for multi-step progress flows.",
+    type: "registry:component",
+    registryDependencies: undefined,
+    files: [{
+      path: "registry/default/example/stepper.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/stepper.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "stepper"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "swap-form": {
+    name: "swap-form",
+    description: "A form panel with animated mode switching and fluid content transitions.",
+    type: "registry:component",
+    registryDependencies: undefined,
+    files: [{
+      path: "registry/default/example/swap-form.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/swap-form.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "swap-form"
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,

--- a/registry/__index__.tsx
+++ b/registry/__index__.tsx
@@ -60,6 +60,60 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
+  "copy-button": {
+    name: "copy-button",
+    description: "A button that copies text to the clipboard with visual feedback.",
+    type: "registry:component",
+    registryDependencies: undefined,
+    files: [{
+      path: "registry/default/example/copy-button.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/copy-button.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "copy-button"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "stepper": {
+    name: "stepper",
+    description: "An interactive stepper component with smooth transitions and visual feedback.",
+    type: "registry:component",
+    registryDependencies: undefined,
+    files: [{
+      path: "registry/default/example/stepper.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/stepper")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "stepper"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "counter": {
+    name: "counter",
+    description: "A simple counter component with smooth animations.",
+    type: "registry:component",
+    registryDependencies: undefined,
+    files: [{
+      path: "registry/default/example/counter.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/counter")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "counter"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
   "day-picker": {
     name: "day-picker",
     description: "A custom day picker component with smooth animations.",
@@ -481,6 +535,42 @@ export const Index: Record<string, any> = {
     component: React.lazy(async () => {
       const mod = await import("@/registry/default/demo/empty-testimonial-demo.tsx")
       const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "empty-testimonial"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+    "swap-form": {
+    name: "swap-form",
+    description: "A dynamic, animated swap form with validation.",
+    type: "registry:component",
+    registryDependencies: ["card","button","input","textarea","select","badge","calendar","popover"],
+    files: [{
+      path: "registry/default/example/swap-form.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/swap-form.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "swap-form"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+      "add-cash": {
+    name: "add-cash",
+    description: "A dynamic, animated add cash widget with validation.",
+    type: "registry:component",
+    registryDependencies: ["card","button","input","textarea","select","badge","calendar","popover"],
+    files: [{
+      path: "registry/default/example/add-cash.tsx",
+      type: "registry:component",
+      target: ""
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/default/example/add-cash.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "add-cash"
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,

--- a/registry/default/example/add-cash.tsx
+++ b/registry/default/example/add-cash.tsx
@@ -1,0 +1,402 @@
+// ADD-CASH.TSX
+
+"use client";
+
+import { useRef, useState } from "react";
+import { motion } from "motion/react";
+
+const SP = {
+  type: "spring",
+  stiffness: 520,
+  damping: 42,
+  mass: 0.72,
+};
+
+const WalletIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.7"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="text-zinc-500 dark:text-zinc-400"
+  >
+    <rect
+      x="2"
+      y="5"
+      width="20"
+      height="14"
+      rx="3"
+    />
+    <path d="M16 12h2" />
+    <path d="M2 10h20" />
+  </svg>
+);
+
+const PlusIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+  >
+    <path d="M12 5v14M5 12h14" />
+  </svg>
+);
+
+const CloseIcon = () => (
+  <svg
+    width="11"
+    height="11"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+  >
+    <path d="M18 6 6 18M6 6l12 12" />
+  </svg>
+);
+
+const VisaIcon = () => (
+  <div className="text-[13px] font-black tracking-[0.18em] text-blue-700 dark:text-blue-400">
+    VISA
+  </div>
+);
+
+const MastercardIcon = () => (
+  <div className="flex items-center">
+    <div className="h-4 w-4 rounded-full bg-red-500" />
+    <div className="-ml-1 h-4 w-4 rounded-full bg-yellow-400" />
+  </div>
+);
+
+export default function AddCash() {
+  const [open, setOpen] =
+    useState(false);
+
+  const [selectedCard, setSelectedCard] =
+    useState("4632");
+
+  const [selectedAmount, setSelectedAmount] =
+    useState(300);
+
+  const [customAmount, setCustomAmount] =
+    useState("300");
+
+  const inputRef =
+    useRef<HTMLInputElement>(null);
+
+  const amounts = [
+    50,
+    100,
+    null,
+  ];
+
+  const effectiveAmount =
+    selectedAmount === null
+      ? parseFloat(customAmount) || 0
+      : selectedAmount;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-100 dark:bg-black p-6">
+
+      <motion.div
+        layout="size"
+        transition={SP}
+        className="relative w-[400px] overflow-hidden rounded-[28px] border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-[0_10px_40px_rgba(0,0,0,0.12)] dark:shadow-[0_10px_40px_rgba(0,0,0,0.4)]"
+      >
+        {/* Header */}
+
+        <motion.div
+          layout="position"
+          transition={SP}
+          className="flex items-center gap-3 border-b border-transparent px-[18px] py-[18px]"
+        >
+          <motion.div
+            layout
+            transition={SP}
+            className="flex h-11 w-11 items-center justify-center rounded-[14px] bg-zinc-100 dark:bg-zinc-900"
+          >
+            <WalletIcon />
+          </motion.div>
+
+          <motion.div
+            layout="position"
+            transition={SP}
+            className="flex-1"
+          >
+            <div className="mb-0.5 text-[11px] font-medium text-zinc-400 dark:text-zinc-500">
+              Wallet
+            </div>
+
+            <div className="text-[20px] font-bold tracking-[-0.04em] text-zinc-950 dark:text-white">
+              $34.00
+            </div>
+          </motion.div>
+
+          {!open ? (
+            <motion.button
+              layout
+              layoutId="top-action"
+              whileTap={{
+                scale: 0.96,
+              }}
+              transition={SP}
+              onClick={() =>
+                setOpen(true)
+              }
+              className="flex items-center gap-1.5 rounded-full bg-zinc-950 dark:bg-white px-4 py-2.5 text-[13px] font-semibold text-white dark:text-zinc-950 shadow-sm"
+            >
+              <PlusIcon />
+              Add Cash
+            </motion.button>
+          ) : (
+            <motion.button
+              layout
+              layoutId="top-action"
+              whileTap={{
+                scale: 0.9,
+              }}
+              transition={SP}
+              onClick={() =>
+                setOpen(false)
+              }
+              className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-900 text-zinc-500 dark:text-zinc-400"
+            >
+              <CloseIcon />
+            </motion.button>
+          )}
+        </motion.div>
+
+        {/* Expanded content */}
+
+        <motion.div
+          layout
+          animate={{
+            height: open
+              ? "auto"
+              : 0,
+            opacity: open
+              ? 1
+              : 0,
+          }}
+          transition={{
+            ...SP,
+            opacity: {
+              duration: 0.14,
+            },
+          }}
+          className="overflow-hidden"
+        >
+          <motion.div
+            layout
+            transition={SP}
+            className="px-[18px] pb-[18px]"
+          >
+            {/* Payment mode */}
+
+            <div className="mb-3 flex items-center justify-between">
+              <span className="text-[11px] font-medium text-zinc-400 dark:text-zinc-500">
+                Payment Mode
+              </span>
+
+              <button className="rounded-full border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-950 px-3 py-1.5 text-[11px] font-medium text-zinc-700 dark:text-zinc-300">
+                Add Card
+              </button>
+            </div>
+
+            {/* Cards */}
+
+            <div className="mb-4 flex flex-col gap-2">
+              {[
+                {
+                  id: "6756",
+                  icon: <VisaIcon />,
+                },
+                {
+                  id: "4632",
+                  icon:
+                    <MastercardIcon />,
+                },
+              ].map((card) => {
+                const selected =
+                  selectedCard ===
+                  card.id;
+
+                return (
+                  <motion.div
+                    key={card.id}
+                    layout
+                    transition={SP}
+                    onClick={() =>
+                      setSelectedCard(
+                        card.id
+                      )
+                    }
+                    className="relative cursor-pointer rounded-[14px]"
+                  >
+                    {selected && (
+                      <motion.div
+                        layoutId="card-outline"
+                        transition={SP}
+                        className="absolute inset-0 rounded-[14px] border border-zinc-950 dark:border-white"
+                      />
+                    )}
+
+                    <motion.div
+                      layout="position"
+                      transition={SP}
+                      whileHover={{
+                        backgroundColor:
+                          "rgba(0,0,0,0.02)",
+                      }}
+                      className="flex items-center gap-3 rounded-[14px] px-[14px] py-3 dark:hover:bg-white/[0.03]"
+                    >
+                      <motion.div
+                        animate={{
+                          borderWidth:
+                            selected
+                              ? 5
+                              : 1.5,
+                        }}
+                        transition={SP}
+                        className={`h-[18px] w-[18px] rounded-full border ${
+                          selected
+                            ? "border-zinc-950 dark:border-white"
+                            : "border-zinc-300 dark:border-zinc-700"
+                        }`}
+                      />
+
+                      <span className="flex-1 text-[13px] font-semibold tracking-[0.04em] text-zinc-950 dark:text-white">
+                        ···· {card.id}
+                      </span>
+
+                      {card.icon}
+                    </motion.div>
+                  </motion.div>
+                );
+              })}
+            </div>
+
+            {/* Cash label */}
+
+            <div className="mb-2 text-[11px] font-medium text-zinc-400 dark:text-zinc-500">
+              Cash
+            </div>
+
+            {/* Amounts */}
+
+            <div className="mb-5 flex gap-2">
+              {amounts.map(
+                (amt, i) => {
+                  const selected =
+                    selectedAmount ===
+                    amt;
+
+                  const isCustom =
+                    amt === null;
+
+                  return (
+                    <motion.div
+                      key={i}
+                      layout
+                      transition={SP}
+                      onClick={() => {
+                        setSelectedAmount(
+                          amt
+                        );
+
+                        if (
+                          isCustom
+                        ) {
+                          setTimeout(
+                            () =>
+                              inputRef.current?.focus(),
+                            40
+                          );
+                        }
+                      }}
+                      className="relative flex-1 cursor-pointer"
+                    >
+                      {selected && (
+                        <motion.div
+                          layoutId="amount-outline"
+                          transition={SP}
+                          className="absolute inset-0 rounded-[12px] border border-zinc-950 dark:border-white"
+                        />
+                      )}
+
+                      <motion.div
+                        whileTap={{
+                          scale: 0.97,
+                        }}
+                        transition={SP}
+                        className={`flex h-[42px] items-center justify-center rounded-[12px] text-[13px] font-semibold ${
+                          selected
+                            ? "bg-white dark:bg-zinc-950 text-zinc-950 dark:text-white"
+                            : "bg-zinc-100 dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300"
+                        }`}
+                      >
+                        {isCustom ? (
+                          <span className="flex items-center gap-0.5">
+                            $
+                            <input
+                              ref={
+                                inputRef
+                              }
+                              value={
+                                customAmount
+                              }
+                              onChange={(
+                                e
+                              ) =>
+                                setCustomAmount(
+                                  e
+                                    .target
+                                    .value
+                                )
+                              }
+                              className="w-11 bg-transparent text-center text-[13px] font-semibold outline-none text-zinc-950 dark:text-white"
+                            />
+                          </span>
+                        ) : (
+                          `$${amt}`
+                        )}
+                      </motion.div>
+                    </motion.div>
+                  );
+                }
+              )}
+            </div>
+
+            {/* CTA */}
+
+            <motion.button
+              layout
+              whileHover={{
+                scale: 1.01,
+              }}
+              whileTap={{
+                scale: 0.985,
+              }}
+              transition={SP}
+              className="h-12 w-full rounded-full bg-zinc-950 dark:bg-white text-[14px] font-semibold text-white dark:text-zinc-950 shadow-[0_2px_12px_rgba(0,0,0,0.22)]"
+            >
+              Add $
+              {effectiveAmount.toFixed(
+                0
+              )}
+            </motion.button>
+          </motion.div>
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}

--- a/registry/default/example/copy-button.tsx
+++ b/registry/default/example/copy-button.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { motion, AnimatePresence } from "motion/react";
+import { useState } from "react";
+
+const CopyButton = () => {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = () => {
+    if (copied) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex items-center justify-center">
+      <motion.button
+        onClick={handleClick}
+        whileTap={{ scale: 0.95 }}
+        className="px-5 py-3 rounded-full font-medium overflow-hidden"
+        animate={{
+          backgroundColor: copied ? "#22c55e" : "#18181b",
+          color: "#ffffff",
+        }}
+        transition={{ duration: 0.3 }}
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          {!copied ? (
+            <motion.span
+              key="copy"
+              initial={{ y: 20, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: -20, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ display: "block" }}
+            >
+              Copy
+            </motion.span>
+          ) : (
+            <motion.span
+              key="copied"
+              initial={{ y: 20, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: -20, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ display: "block" }}
+            >
+              ✓ Copied!
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </motion.button>
+    </div>
+  );
+};
+
+export default CopyButton;

--- a/registry/default/example/counter.tsx
+++ b/registry/default/example/counter.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { motion, AnimatePresence } from "motion/react";
+import { useState } from "react";
+
+const SPRING = {
+  type: "spring",
+  stiffness: 420,
+  damping: 32,
+  mass: 0.8,
+};
+
+const Counter = ({
+  min = 0,
+  max = 99,
+  defaultValue = 0,
+}) => {
+  const [count, setCount] = useState(defaultValue);
+  const [direction, setDirection] = useState(1);
+
+  const increment = () => {
+    if (count >= max) return;
+
+    setDirection(1);
+    setCount((c) => c + 1);
+  };
+
+  const decrement = () => {
+    if (count <= min) return;
+
+    setDirection(-1);
+    setCount((c) => c - 1);
+  };
+
+  // Only pad after 10
+  const formatted =
+    count < 10
+      ? count.toString()
+      : count.toString().padStart(2, "0");
+
+  const previousFormatted =
+    (direction > 0 ? count - 1 : count + 1) < 10
+      ? (direction > 0
+          ? count - 1
+          : count + 1
+        ).toString()
+      : (direction > 0
+          ? count - 1
+          : count + 1
+        )
+          .toString()
+          .padStart(2, "0");
+
+  const currentDigits = formatted.split("");
+  const previousDigits =
+    previousFormatted.split("");
+
+  return (
+    <div className="flex items-center gap-4">
+      {/* Minus */}
+      <motion.button
+        whileTap={{ scale: 0.88 }}
+        transition={SPRING}
+        onClick={decrement}
+        disabled={count <= min}
+        className="w-11 h-11 rounded-full border border-zinc-200 dark:border-zinc-700 flex items-center justify-center text-zinc-700 dark:text-zinc-300 text-xl font-medium disabled:opacity-30 disabled:cursor-not-allowed select-none bg-white dark:bg-zinc-900 shadow-sm"
+      >
+        −
+      </motion.button>
+
+      {/* Counter */}
+      <motion.div
+        layout
+        transition={SPRING}
+        className="relative flex items-center justify-center min-w-[34px] h-[42px]"
+      >
+        <div className="flex items-center">
+          {currentDigits.map((digit, index) => {
+            const prevDigit =
+              previousDigits[index];
+
+            const changed =
+              prevDigit !== digit;
+
+            return (
+              <div
+                key={index}
+                className="relative w-[16px] h-[30px] overflow-hidden flex items-center justify-center"
+              >
+                <AnimatePresence
+                  mode="sync"
+                  initial={false}
+                >
+                  <motion.span
+                    key={`${index}-${digit}`}
+                    initial={
+                      changed
+                        ? {
+                            y:
+                              direction > 0
+                                ? 26
+                                : -26,
+                            opacity: 0,
+                            scale: 0.92,
+                          }
+                        : false
+                    }
+                    animate={{
+                      y: 0,
+                      opacity: 1,
+                      scale: 1,
+                    }}
+                    exit={
+                      changed
+                        ? {
+                            y:
+                              direction > 0
+                                ? -26
+                                : 26,
+                            opacity: 0,
+                            scale: 0.92,
+                          }
+                        : {}
+                    }
+                    transition={{
+                      ...SPRING,
+                      opacity: {
+                        duration: 0.14,
+                      },
+                    }}
+                    className="absolute text-[28px] font-semibold tracking-[-0.04em] leading-none text-zinc-950 dark:text-white tabular-nums"
+                    style={{
+                      willChange:
+                        "transform, opacity",
+                    }}
+                  >
+                    {digit}
+                  </motion.span>
+                </AnimatePresence>
+              </div>
+            );
+          })}
+        </div>
+      </motion.div>
+
+      {/* Plus */}
+      <motion.button
+        whileTap={{ scale: 0.88 }}
+        transition={SPRING}
+        onClick={increment}
+        disabled={count >= max}
+        className="w-11 h-11 rounded-full bg-zinc-950 dark:bg-white flex items-center justify-center text-white dark:text-zinc-900 text-xl font-medium disabled:opacity-30 disabled:cursor-not-allowed select-none shadow-sm"
+      >
+        +
+      </motion.button>
+    </div>
+  );
+};
+
+export default Counter;

--- a/registry/default/example/flower-menu.tsx
+++ b/registry/default/example/flower-menu.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { motion } from "motion/react";
+import {
+  Bell,
+  Flame,
+  Folder,
+  Hexagon,
+  Image,
+  Magnet,
+  Mic,
+  Plus,
+  Search,
+  Sparkles,
+} from "lucide-react";
+import { type ComponentType, useMemo, useState } from "react";
+
+type FlowerItem = {
+  id: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+const ITEMS: FlowerItem[] = [
+  { id: "bell", icon: Bell },
+  { id: "sparkles", icon: Sparkles },
+  { id: "mic", icon: Mic },
+  { id: "magnet", icon: Magnet },
+  { id: "folder", icon: Folder },
+  { id: "image", icon: Image },
+  { id: "search", icon: Search },
+  { id: "flame", icon: Flame },
+  { id: "hexagon", icon: Hexagon },
+  { id: "dots", icon: Sparkles },
+];
+
+const EASE = [0.22, 1, 0.36, 1] as const;
+const RADIUS = 88;
+const STEP = (Math.PI * 2) / ITEMS.length;
+
+export default function FlowerMenu() {
+  const [open, setOpen] = useState(false);
+
+  const points = useMemo(
+    () =>
+      ITEMS.map((item, index) => {
+        const angle = -Math.PI / 2 + index * STEP;
+
+        return {
+          ...item,
+          x: Math.cos(angle) * RADIUS,
+          y: Math.sin(angle) * RADIUS,
+        };
+      }),
+    [],
+  );
+
+  return (
+    <div className="flex h-[420px] w-full items-center justify-center rounded-xl bg-[#efede5] dark:bg-zinc-900">
+      <div className="relative h-[280px] w-[280px]">
+        <div className="absolute left-1/2 top-1/2 h-0 w-0">
+          {points.map((point, index) => {
+            const Icon = point.icon;
+
+            return (
+              <motion.button
+                key={point.id}
+                type="button"
+                animate={{
+                  x: open ? point.x : 0,
+                  y: open ? point.y : 0,
+                  opacity: open ? 1 : 0,
+                  scale: open ? 1 : 0.5,
+                  filter: open ? "blur(0px)" : "blur(4px)",
+                }}
+                transition={{
+                  duration: 0.5,
+                  ease: EASE,
+                  delay: open ? index * 0.03 : (points.length - 1 - index) * 0.03,
+                }}
+                className={`absolute left-0 top-0 flex h-[46px] w-[46px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-zinc-200/90 bg-white text-zinc-500 shadow-[0_10px_24px_rgba(0,0,0,0.14)] dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-200 ${
+                  open ? "pointer-events-auto" : "pointer-events-none"
+                }`}
+                whileTap={{ scale: 0.95 }}
+              >
+                <Icon className="h-5 w-5" />
+              </motion.button>
+            );
+          })}
+
+          <motion.button
+            type="button"
+            onClick={() => setOpen((prev) => !prev)}
+            className="absolute left-0 top-0 z-20 flex h-[58px] w-[58px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-[999px] border border-zinc-200 bg-white text-zinc-600 shadow-[0_10px_24px_rgba(0,0,0,0.14)] dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100"
+            whileTap={{ scale: 0.95 }}
+          >
+            <motion.div
+              animate={{ rotate: open ? 135 : 0 }}
+              transition={{ duration: 0.45, ease: EASE }}
+            >
+              <Plus className="h-[22px] w-[22px]" />
+            </motion.div>
+          </motion.button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/registry/default/example/inline-edit.tsx
+++ b/registry/default/example/inline-edit.tsx
@@ -32,6 +32,7 @@ function SaveInput() {
         )}
         style={{ borderRadius: 60 }}
       >
+       
         <Input
           ref={inputRef}
           value={value}
@@ -39,7 +40,7 @@ function SaveInput() {
           readOnly={!isEditing}
           className={cn(
             "h-12 border-0 shadow-none focus-visible:ring-0 bg-transparent p-0 text-base w-full min-w-32 pl-4 pr-12",
-            isEditing ? "text-foreground" : "text-muted-foreground"
+            isEditing ? "text-foreground" : "caret-transparent text-muted-foreground"
           )}
           placeholder="username"
         />

--- a/registry/default/example/stepper.tsx
+++ b/registry/default/example/stepper.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { motion, AnimatePresence } from "motion/react";
+import { useState } from "react";
+
+// Types
+
+type Step = {
+  title: string;
+  description: string;
+};
+
+type StepperProps = {
+  steps?: Step[];
+  orientation?: "horizontal" | "vertical";
+};
+
+// Default demo steps
+
+const DEFAULT_STEPS: Step[] = [
+  {
+    title: "Your details",
+    description: "Provide your name and email address.",
+  },
+  {
+    title: "Choose a plan",
+    description: "Select the plan that works best for you.",
+  },
+  {
+    title: "Add payment",
+    description: "Enter a credit card or connect your bank.",
+  },
+  {
+    title: "Confirmation",
+    description: "Review your order and confirm your purchase.",
+  },
+];
+
+// Step Circle
+
+const StepCircle = ({
+  index,
+  currentStep,
+  onClick,
+}: {
+  index: number;
+  currentStep: number;
+  onClick: () => void;
+}) => {
+  const isCompleted = index < currentStep;
+  const isActive = index === currentStep;
+
+  return (
+    <button
+      onClick={onClick}
+      className="relative flex items-center justify-center w-10 h-10 rounded-full focus:outline-none"
+      style={{ zIndex: 1 }}
+      aria-label={`Go to step ${index + 1}`}
+    >
+      {/* Track */}
+      <div className="absolute inset-0 rounded-full border-2 border-zinc-200 dark:border-zinc-700" />
+
+      {/* Fill */}
+      <motion.div
+        className="absolute inset-0 rounded-full"
+        initial={false}
+        animate={{
+          scale: isCompleted || isActive ? 1 : 0,
+          backgroundColor:
+            isCompleted || isActive
+              ? "#22c55e"
+              : "#18181b",
+        }}
+        transition={{
+          duration: 0.08,
+          ease: "linear",
+        }}
+      />
+
+      {/* Content */}
+      <AnimatePresence mode="wait" initial={false}>
+        {isCompleted ? (
+          <motion.svg
+            key="check"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="white"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0, opacity: 0 }}
+            transition={{
+              duration: 0.12,
+            }}
+            style={{
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </motion.svg>
+        ) : (
+          <motion.span
+            key={`number-${index}`}
+            initial={{
+              scale: 0.7,
+              opacity: 0,
+            }}
+            animate={{
+              scale: 1,
+              opacity: 1,
+            }}
+            exit={{
+              scale: 0.7,
+              opacity: 0,
+            }}
+            transition={{
+              duration: 0.12,
+            }}
+            className="absolute inset-0 flex items-center justify-center tabular-nums text-[13px] font-semibold"
+            style={{
+              zIndex: 1,
+              color: "#ffffff",
+            }}
+          >
+            {index + 1}
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </button>
+  );
+};
+
+// Connector Line
+
+const ConnectorLine = ({
+  index,
+  currentStep,
+  orientation,
+}: {
+  index: number;
+  currentStep: number;
+  orientation: "horizontal" | "vertical";
+}) => {
+  const isFilled = index < currentStep;
+
+  return (
+    <div
+      className="relative overflow-hidden bg-zinc-200 dark:bg-zinc-700"
+      style={
+        orientation === "horizontal"
+          ? { flex: 1, height: "2px", margin: "0 4px" }
+          : { width: "2px", height: "40px", margin: "4px 19px" }
+      }
+    >
+      <motion.div
+        className="absolute inset-0 bg-green-500"
+        initial={false}
+        animate={
+          orientation === "horizontal"
+            ? { scaleX: isFilled ? 1 : 0 }
+            : { scaleY: isFilled ? 1 : 0 }
+        }
+        style={
+          orientation === "horizontal"
+            ? { transformOrigin: "left" }
+            : { transformOrigin: "top" }
+        }
+        transition={{
+          duration: 0.15,
+          ease: [0.4, 0, 0.2, 1],
+        }}
+      />
+    </div>
+  );
+};
+
+// Main Stepper
+
+const Stepper = ({
+  steps = DEFAULT_STEPS,
+  orientation = "horizontal",
+}: StepperProps) => {
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const goTo = (index: number) => {
+    setCurrentStep(index);
+  };
+
+  const goNext = () => {
+    if (currentStep < steps.length - 1) {
+      setCurrentStep((s) => s + 1);
+    }
+  };
+
+  const goBack = () => {
+    if (currentStep > 0) {
+      setCurrentStep((s) => s - 1);
+    }
+  };
+
+  // Horizontal Layout
+
+  if (orientation === "horizontal") {
+    return (
+      <div className="w-full max-w-2xl mx-auto flex flex-col gap-8 p-6">
+        {/* Indicators */}
+        <div className="flex items-center w-full">
+          {steps.map((step, i) => (
+            <div
+              key={i}
+              className="flex items-center flex-1 last:flex-none"
+            >
+              <div className="flex flex-col items-center gap-2">
+                <StepCircle
+                  index={i}
+                  currentStep={currentStep}
+                  onClick={() => goTo(i)}
+                />
+
+                <span
+                  className="text-xs font-medium text-center whitespace-nowrap transition-colors duration-75"
+                  style={{
+                    color:
+                      i <= currentStep
+                        ? "#22c55e"
+                        : "#a1a1aa",
+                  }}
+                >
+                  {step.title}
+                </span>
+              </div>
+
+              {i < steps.length - 1 && (
+                <ConnectorLine
+                  index={i}
+                  currentStep={currentStep}
+                  orientation="horizontal"
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 overflow-hidden min-h-32">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={currentStep}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{
+                duration: 0.2,
+                ease: [0.4, 0, 0.2, 1],
+              }}
+              className="p-6"
+            >
+              <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100 mb-1">
+                Step {currentStep + 1} —{" "}
+                {steps[currentStep].title}
+              </p>
+
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                {steps[currentStep].description}
+              </p>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* Buttons */}
+        <div className="flex justify-between">
+          <motion.button
+            onClick={goBack}
+            whileTap={{ scale: 0.95 }}
+            disabled={currentStep === 0}
+            className="px-5 py-2 rounded-full text-sm font-medium border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            Back
+          </motion.button>
+
+          <motion.button
+            onClick={goNext}
+            whileTap={{ scale: 0.95 }}
+            disabled={currentStep === steps.length - 1}
+            className="px-5 py-2 rounded-full text-sm font-medium bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            {currentStep === steps.length - 2
+              ? "Finish"
+              : "Next"}
+          </motion.button>
+        </div>
+      </div>
+    );
+  }
+
+  // Vertical Layout
+
+  return (
+    <div className="w-full max-w-sm mx-auto flex flex-col gap-6 p-6">
+      <div className="flex flex-col">
+        {steps.map((step, i) => (
+          <div key={i} className="flex gap-4">
+            {/* Left */}
+            <div className="flex flex-col items-center">
+              <StepCircle
+                index={i}
+                currentStep={currentStep}
+                onClick={() => goTo(i)}
+              />
+
+              {i < steps.length - 1 && (
+                <ConnectorLine
+                  index={i}
+                  currentStep={currentStep}
+                  orientation="vertical"
+                />
+              )}
+            </div>
+
+            {/* Right */}
+            <div className="pb-8 pt-1.5">
+              <p
+                className="text-sm font-semibold mb-0.5 transition-colors duration-75"
+                style={{
+                  color:
+                    i <= currentStep
+                      ? "#22c55e"
+                      : "#a1a1aa",
+                }}
+              >
+                {step.title}
+              </p>
+
+              <AnimatePresence>
+                {i === currentStep && (
+                  <motion.p
+                    initial={{
+                      opacity: 0,
+                      height: 0,
+                    }}
+                    animate={{
+                      opacity: 1,
+                      height: "auto",
+                    }}
+                    exit={{
+                      opacity: 0,
+                      height: 0,
+                    }}
+                    transition={{
+                      duration: 0.2,
+                      ease: [0.4, 0, 0.2, 1],
+                    }}
+                    className="text-sm text-zinc-500 dark:text-zinc-400 overflow-hidden"
+                  >
+                    {step.description}
+                  </motion.p>
+                )}
+              </AnimatePresence>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Buttons */}
+      <div className="flex justify-between">
+        <motion.button
+          onClick={goBack}
+          whileTap={{ scale: 0.95 }}
+          disabled={currentStep === 0}
+          className="px-5 py-2 rounded-full text-sm font-medium border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          Back
+        </motion.button>
+
+        <motion.button
+          onClick={goNext}
+          whileTap={{ scale: 0.95 }}
+          disabled={currentStep === steps.length - 1}
+          className="px-5 py-2 rounded-full text-sm font-medium bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          {currentStep === steps.length - 2
+            ? "Finish"
+            : "Next"}
+        </motion.button>
+      </div>
+    </div>
+  );
+};
+
+export default Stepper;

--- a/registry/default/example/stepper.tsx
+++ b/registry/default/example/stepper.tsx
@@ -154,7 +154,7 @@ const ConnectorLine = ({
       className="relative overflow-hidden bg-zinc-200 dark:bg-zinc-700"
       style={
         orientation === "horizontal"
-          ? { flex: 1, height: "2px", margin: "0 4px" }
+          ? { flex: 1, height: "2px", margin: "19px 4px 0 4px" }
           : { width: "2px", height: "40px", margin: "4px 19px" }
       }
     >
@@ -214,7 +214,7 @@ const Stepper = ({
           {steps.map((step, i) => (
             <div
               key={i}
-              className="flex items-center flex-1 last:flex-none"
+              className="flex items-start flex-1 last:flex-none"
             >
               <div className="flex flex-col items-center gap-2">
                 <StepCircle

--- a/registry/default/example/swap-form.tsx
+++ b/registry/default/example/swap-form.tsx
@@ -1,0 +1,292 @@
+// SWAP-FORM.TSX
+
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import {
+  motion,
+  AnimatePresence,
+  useMotionValue,
+  useSpring,
+} from "motion/react";
+
+const SPRING = {
+  type: "spring",
+  stiffness: 380,
+  damping: 32,
+};
+
+const EASE = [0.4, 0, 0.2, 1];
+
+const GoogleIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+    <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/>
+    <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853"/>
+    <path d="M3.964 10.707A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.707V4.961H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.039l3.007-2.332z" fill="#FBBC05"/>
+    <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.961L3.964 6.293C4.672 4.166 6.656 3.58 9 3.58z" fill="#EA4335"/>
+  </svg>
+);
+
+const AppleIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="currentColor">
+    <path d="M14.94 13.09c-.28.63-.61 1.21-.99 1.74-.52.74-.94 1.25-1.27 1.53-.51.47-1.05.71-1.63.72-.42 0-.92-.12-1.5-.36-.58-.24-1.12-.36-1.6-.36-.51 0-1.05.12-1.64.36-.59.24-1.07.37-1.44.38-.56.02-1.11-.23-1.65-.75-.36-.3-.8-.83-1.33-1.59C2.3 13.92 1.8 13 1.41 11.96c-.42-1.11-.63-2.19-.63-3.23 0-1.19.26-2.22.77-3.07.41-.68.95-1.22 1.63-1.62.68-.4 1.41-.6 2.2-.61.43 0 1 .13 1.71.4.71.26 1.16.4 1.36.4.15 0 .66-.16 1.52-.47.81-.29 1.5-.41 2.07-.36 1.53.12 2.68.72 3.44 1.8-1.37.83-2.05 1.99-2.04 3.48.01 1.16.43 2.13 1.27 2.88.38.36.8.64 1.27.83-.1.3-.21.58-.34.86z" />
+  </svg>
+);
+
+const InputField = ({
+  label,
+  type,
+  placeholder,
+}: {
+  label: string;
+  type: string;
+  placeholder: string;
+}) => {
+  const [focused, setFocused] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-[13px] font-medium text-zinc-700 dark:text-zinc-300 tracking-[-0.01em]">
+        {label}
+      </label>
+
+      <motion.div
+        animate={{
+          boxShadow: focused
+            ? "0 0 0 3px rgba(255,255,255,0.08)"
+            : "0 0 0 1px rgba(0,0,0,0.08)",
+        }}
+        transition={{
+          duration: 0.18,
+          ease: EASE,
+        }}
+        className="rounded-xl bg-white dark:bg-zinc-900"
+      >
+        <input
+          type={type}
+          placeholder={placeholder}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          className="w-full rounded-xl bg-transparent px-3.5 py-3 text-sm text-zinc-900 dark:text-white outline-none placeholder:text-zinc-400 dark:placeholder:text-zinc-500"
+        />
+      </motion.div>
+    </div>
+  );
+};
+
+const SocialButton = ({
+  icon,
+  label,
+}: {
+  icon: React.ReactNode;
+  label: string;
+}) => {
+  return (
+    <motion.button
+      whileHover={{ scale: 1.01 }}
+      whileTap={{ scale: 0.98 }}
+      transition={{ duration: 0.15 }}
+      className="flex w-full items-center justify-center gap-2.5 rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-3 text-sm font-medium text-zinc-900 dark:text-white shadow-sm"
+    >
+      {icon}
+      <span>{label}</span>
+    </motion.button>
+  );
+};
+
+const Divider = () => (
+  <div className="mb-5 flex items-center gap-3">
+    <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-700" />
+
+    <span className="text-[11px] font-medium tracking-[0.06em] text-zinc-400 dark:text-zinc-500">
+      OR
+    </span>
+
+    <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-700" />
+  </div>
+);
+
+export default function SwapForm() {
+  const [mode, setMode] = useState("signup");
+
+  const mouseX = useMotionValue(0);
+  const mouseY = useMotionValue(0);
+
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const springX = useSpring(mouseX, {
+    stiffness: 80,
+    damping: 20,
+  });
+
+  const springY = useSpring(mouseY, {
+    stiffness: 80,
+    damping: 20,
+  });
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!cardRef.current) return;
+
+      const rect =
+        cardRef.current.getBoundingClientRect();
+
+      mouseX.set(e.clientX - rect.left);
+      mouseY.set(e.clientY - rect.top);
+    };
+
+    window.addEventListener(
+      "mousemove",
+      handleMouseMove
+    );
+
+    return () =>
+      window.removeEventListener(
+        "mousemove",
+        handleMouseMove
+      );
+  }, []);
+
+  return (
+    <div className="relative flex h-[720px] w-full items-center justify-center overflow-hidden rounded-3xl bg-gradient-to-br from-zinc-100 via-zinc-200 to-zinc-100 dark:from-zinc-950 dark:via-zinc-900 dark:to-black p-6">
+
+      <div className="absolute -right-28 -top-28 h-[420px] w-[420px] rounded-full bg-[radial-gradient(circle,rgba(180,180,255,0.18)_0%,transparent_70%)] blur-[40px]" />
+
+      <div className="absolute -bottom-24 -left-24 h-[320px] w-[320px] rounded-full bg-[radial-gradient(circle,rgba(255,180,160,0.14)_0%,transparent_70%)] blur-[40px]" />
+
+      <motion.div
+        ref={cardRef}
+        layout
+        transition={{
+          type: "spring",
+          stiffness: 280,
+          damping: 34,
+        }}
+        className="relative w-full max-w-[420px] overflow-hidden rounded-[28px] bg-white/90 dark:bg-zinc-900/90 p-8 shadow-[0_8px_32px_rgba(0,0,0,0.08),0_2px_8px_rgba(0,0,0,0.04)] backdrop-blur-2xl"
+      >
+        <motion.div
+          style={{
+            x: springX,
+            y: springY,
+            translateX: "-50%",
+            translateY: "-50%",
+          }}
+          className="pointer-events-none absolute z-0 h-40 w-40 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.3)_0%,transparent_70%)] blur-3xl dark:bg-[radial-gradient(circle,rgba(255,255,255,0.08)_0%,transparent_70%)]"
+        />
+
+        <div className="relative z-10">
+          <AnimatePresence
+            mode="wait"
+            initial={false}
+          >
+            <motion.div
+              key={mode}
+              initial={{
+                opacity: 0,
+                y: -24,
+              }}
+              animate={{
+                opacity: 1,
+                y: 0,
+              }}
+              exit={{
+                opacity: 0,
+                y: -24,
+              }}
+              transition={{
+                duration: 0.28,
+                ease: EASE,
+              }}
+            >
+              <div className="mb-6">
+                <h1 className="mb-1 text-[22px] font-bold tracking-[-0.03em] text-zinc-950 dark:text-white">
+                  {mode === "signup"
+                    ? "Create Account"
+                    : "Sign In"}
+                </h1>
+
+                <p className="text-[13.5px] text-zinc-500 dark:text-zinc-400">
+                  {mode === "signup"
+                    ? "Just one more step to get started!"
+                    : "Hey friend, welcome back!"}
+                </p>
+              </div>
+
+              <div className="mb-5 flex flex-col gap-2.5">
+                <SocialButton
+                  icon={<GoogleIcon />}
+                  label="Continue with Google"
+                />
+
+                <SocialButton
+                  icon={<AppleIcon />}
+                  label="Continue with Apple"
+                />
+              </div>
+
+              <Divider />
+
+              <div className="mb-5 flex flex-col gap-3.5">
+                {mode === "signup" && (
+                  <InputField
+                    label="Full Name"
+                    type="text"
+                    placeholder="Your name"
+                  />
+                )}
+
+                <InputField
+                  label="Email"
+                  type="email"
+                  placeholder="you@example.com"
+                />
+
+                {mode === "signup" && (
+                  <InputField
+                    label="Password"
+                    type="password"
+                    placeholder="Create a password"
+                  />
+                )}
+              </div>
+
+              <motion.button
+                whileHover={{ scale: 1.015 }}
+                whileTap={{ scale: 0.97 }}
+                transition={SPRING}
+                className="mb-5 w-full rounded-[14px] bg-zinc-950 dark:bg-white py-3 text-sm font-semibold text-white dark:text-zinc-950"
+              >
+                {mode === "signup"
+                  ? "Create Account"
+                  : "Get Sign In Code"}
+              </motion.button>
+
+              <div className="text-center">
+                <p className="text-[13px] text-zinc-500 dark:text-zinc-400">
+                  {mode === "signup"
+                    ? "Already have account?"
+                    : "Don't have account?"}{" "}
+
+                  <button
+                    onClick={() =>
+                      setMode((m) =>
+                        m === "signup"
+                          ? "signin"
+                          : "signup"
+                      )
+                    }
+                    className="font-semibold text-zinc-800 dark:text-zinc-200"
+                  >
+                    {mode === "signup"
+                      ? "Sign In"
+                      : "Create Account"}
+                  </button>
+                </p>
+              </div>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/registry/default/example/swap-form.tsx
+++ b/registry/default/example/swap-form.tsx
@@ -2,13 +2,8 @@
 
 "use client";
 
-import { useState, useRef, useEffect } from "react";
-import {
-  motion,
-  AnimatePresence,
-  useMotionValue,
-  useSpring,
-} from "motion/react";
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
 
 const SPRING = {
   type: "spring",
@@ -109,53 +104,9 @@ const Divider = () => (
 export default function SwapForm() {
   const [mode, setMode] = useState("signup");
 
-  const mouseX = useMotionValue(0);
-  const mouseY = useMotionValue(0);
-
-  const cardRef = useRef<HTMLDivElement>(null);
-
-  const springX = useSpring(mouseX, {
-    stiffness: 80,
-    damping: 20,
-  });
-
-  const springY = useSpring(mouseY, {
-    stiffness: 80,
-    damping: 20,
-  });
-
-  useEffect(() => {
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!cardRef.current) return;
-
-      const rect =
-        cardRef.current.getBoundingClientRect();
-
-      mouseX.set(e.clientX - rect.left);
-      mouseY.set(e.clientY - rect.top);
-    };
-
-    window.addEventListener(
-      "mousemove",
-      handleMouseMove
-    );
-
-    return () =>
-      window.removeEventListener(
-        "mousemove",
-        handleMouseMove
-      );
-  }, []);
-
   return (
-    <div className="relative flex h-[720px] w-full items-center justify-center overflow-hidden rounded-3xl bg-gradient-to-br from-zinc-100 via-zinc-200 to-zinc-100 dark:from-zinc-950 dark:via-zinc-900 dark:to-black p-6">
-
-      <div className="absolute -right-28 -top-28 h-[420px] w-[420px] rounded-full bg-[radial-gradient(circle,rgba(180,180,255,0.18)_0%,transparent_70%)] blur-[40px]" />
-
-      <div className="absolute -bottom-24 -left-24 h-[320px] w-[320px] rounded-full bg-[radial-gradient(circle,rgba(255,180,160,0.14)_0%,transparent_70%)] blur-[40px]" />
-
+    <div className="relative flex h-[720px] w-full items-center justify-center overflow-hidden rounded-3xl bg-zinc-100 p-6 dark:bg-zinc-950">
       <motion.div
-        ref={cardRef}
         layout
         transition={{
           type: "spring",
@@ -164,16 +115,6 @@ export default function SwapForm() {
         }}
         className="relative w-full max-w-[420px] overflow-hidden rounded-[28px] bg-white/90 dark:bg-zinc-900/90 p-8 shadow-[0_8px_32px_rgba(0,0,0,0.08),0_2px_8px_rgba(0,0,0,0.04)] backdrop-blur-2xl"
       >
-        <motion.div
-          style={{
-            x: springX,
-            y: springY,
-            translateX: "-50%",
-            translateY: "-50%",
-          }}
-          className="pointer-events-none absolute z-0 h-40 w-40 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.3)_0%,transparent_70%)] blur-3xl dark:bg-[radial-gradient(circle,rgba(255,255,255,0.08)_0%,transparent_70%)]"
-        />
-
         <div className="relative z-10">
           <AnimatePresence
             mode="wait"


### PR DESCRIPTION
### Updated Components

- **Inline Edit** — fixed when the textbox is disabled the cursor still shows up


### New Components

- **Stepper** — Horizontal and vertical multi-step progress indicator with
  animated circles, connector line fill, and clickable steps
- **Swap Form** — Morphing Sign In / Sign Up auth card with full-form
  fade-up transition and shared layout animations
- **Copy Button** — Click-to-copy button with sliding text swap animation
- **Counter** — Increment/decrement counter with directional number
  slide animation (odometer style)
- **Add Cash Widget** — Expandable wallet card with shared layout morph,
  sliding card/amount selection outlines, stripe loader, and done state
- **Flower Menu** — Expandable flower styled widget